### PR TITLE
Fix prefix in CliSyntax

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -9,10 +9,10 @@ public class CliSyntax {
     public static final Prefix PREFIX_NAME = new Prefix("-n");
     public static final Prefix PREFIX_PERSON_ID = new Prefix("-id");
     public static final Prefix PREFIX_EVENT_ID = new Prefix("-eid");
-    public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_PHONE = new Prefix("-p");
+    public static final Prefix PREFIX_EMAIL = new Prefix("-e");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("-a");
+    public static final Prefix PREFIX_TAG = new Prefix("-t");
     public static final Prefix PREFIX_EVENT_NAME = new Prefix("-en");
     public static final Prefix PREFIX_EVENT_START_TIME = new Prefix("-st");
     public static final Prefix PREFIX_EVENT_END_TIME = new Prefix("-et");


### PR DESCRIPTION
There are inconsistencies on the prefix used for cli syntax. Some uses `/` and some uses `-`.

To keep it consistent, changes has been made so that all prefix uses `-`.