### PR TITLE
Fix bug empty fields note

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -22,12 +22,12 @@ public class AddNoteCommand extends AddCommand {
     public static final String MESSAGE_PERSON_NOT_FOUND = "Can not find the target contact with ID: ";
 
     private final Note toAdd;
-    private final int contactId;
+    private final ContactID contactId;
 
     /**
      * Creates an AddNoteCommand to add the specified {@code Note}
      */
-    public AddNoteCommand(int contactId, Note note) {
+    public AddNoteCommand(ContactID contactId, Note note) {
         requireNonNull(note);
         this.contactId = contactId;
         this.toAdd = note;
@@ -36,7 +36,7 @@ public class AddNoteCommand extends AddCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        Person person = model.findPersonByUserFriendlyId(ContactID.fromInt(this.contactId));
+        Person person = model.findPersonByUserFriendlyId(this.contactId);
         if (person == null) {
             throw new CommandException(MESSAGE_PERSON_NOT_FOUND + this.contactId);
         }
@@ -59,7 +59,7 @@ public class AddNoteCommand extends AddCommand {
         AddNoteCommand otherAddNoteCommand = (AddNoteCommand) other;
 
         boolean equalToAdd = toAdd.equals(otherAddNoteCommand.toAdd);
-        boolean equalContactId = (contactId == otherAddNoteCommand.contactId);
+        boolean equalContactId = contactId.equals(otherAddNoteCommand.contactId);
         return equalToAdd && equalContactId;
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -5,6 +5,8 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.note.Note;
+import seedu.address.model.note.NoteID;
 import seedu.address.model.person.ContactID;
 import seedu.address.model.person.Person;
 
@@ -20,12 +22,12 @@ public class DeleteNoteCommand extends DeleteCommand {
     public static final String MESSAGE_SUCCESS = "Successfully deleted note: ";
     public static final String MESSAGE_NOTE_NOT_FOUND = "Note not found: ID = ";
 
-    private final int noteIdToDelete;
-    private final int contactId;
+    private final NoteID noteIdToDelete;
+    private final ContactID contactId;
     /**
-     * Creates an DeleteEventCommand to delete the specified {@code Event}
+     * Creates a DeleteNoteCommand to delete the specified {@code Note}
      */
-    public DeleteNoteCommand(int contactId, int noteIdToDelete) {
+    public DeleteNoteCommand(ContactID contactId, NoteID noteIdToDelete) {
         this.contactId = contactId;
         this.noteIdToDelete = noteIdToDelete;
     }
@@ -33,16 +35,16 @@ public class DeleteNoteCommand extends DeleteCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        Person person = model.findPersonByUserFriendlyId(ContactID.fromInt(this.contactId));
+        Person person = model.findPersonByUserFriendlyId(this.contactId);
         if (person == null) {
             throw new CommandException(MESSAGE_PERSON_NOT_FOUND + this.contactId);
         }
-        boolean success = person.removeNoteByUserFriendlyId(this.noteIdToDelete);
-        if (!success) {
+        Note deletedNote = person.removeNoteByUserFriendlyId(this.noteIdToDelete);
+        if (deletedNote == null) {
             throw new CommandException(MESSAGE_NOTE_NOT_FOUND + this.noteIdToDelete);
         }
 
-        return new CommandResult(MESSAGE_SUCCESS + this.noteIdToDelete);
+        return new CommandResult(MESSAGE_SUCCESS + this.noteIdToDelete + ". " + deletedNote.getTitle());
     }
 
     @Override
@@ -58,8 +60,8 @@ public class DeleteNoteCommand extends DeleteCommand {
 
         DeleteNoteCommand otherDeleteNoteCommand = (DeleteNoteCommand) other;
 
-        boolean equalNoteIdToDelete = (noteIdToDelete == otherDeleteNoteCommand.noteIdToDelete);
-        boolean equalContactId = (contactId == otherDeleteNoteCommand.contactId);
+        boolean equalNoteIdToDelete = noteIdToDelete.equals(otherDeleteNoteCommand.noteIdToDelete);
+        boolean equalContactId = contactId.equals(otherDeleteNoteCommand.contactId);
         return equalNoteIdToDelete && equalContactId;
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_INTEGER_ARGUMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_TITLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ID;
@@ -9,6 +8,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ID;
 import seedu.address.logic.commands.AddNoteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.note.Note;
+import seedu.address.model.note.NoteContent;
+import seedu.address.model.note.NoteTitle;
+import seedu.address.model.person.ContactID;
 
 /**
  * Parses input arguments and creates a new AddNoteCommand object
@@ -26,16 +28,10 @@ public class AddNoteCommandParser implements Parser<AddNoteCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PERSON_ID, PREFIX_NOTE_TITLE, PREFIX_NOTE_CONTENT);
 
-        String noteTitle = argMultimap.getValue(PREFIX_NOTE_TITLE).get();
-        String noteContent = argMultimap.getValue(PREFIX_NOTE_CONTENT).get();
+        NoteTitle noteTitle = ParserUtil.parseNoteTitle(argMultimap.getValue(PREFIX_NOTE_TITLE).get());
+        NoteContent noteContent = ParserUtil.parseNoteContent(argMultimap.getValue(PREFIX_NOTE_CONTENT).get());
         Note newNote = new Note(noteTitle, noteContent);
-
-        int contactId = -1;
-        try {
-            contactId = Integer.parseInt(argMultimap.getValue(PREFIX_PERSON_ID).get());
-        } catch (NumberFormatException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_INTEGER_ARGUMENT, e.getMessage()));
-        }
+        ContactID contactId = ParserUtil.parseContactID(argMultimap.getValue(PREFIX_PERSON_ID).get());
 
         return new AddNoteCommand(contactId, newNote);
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
@@ -1,12 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_INTEGER_ARGUMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ID;
 
 import seedu.address.logic.commands.DeleteNoteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.note.NoteID;
+import seedu.address.model.person.ContactID;
 
 /**
  * Parses input arguments and creates a new DeleteNoteCommand object
@@ -22,14 +23,9 @@ public class DeleteNoteCommandParser implements Parser<DeleteNoteCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PERSON_ID, PREFIX_NOTE_ID);
-        int contactId = -1;
-        int noteId = -1;
-        try {
-            contactId = Integer.parseInt(argMultimap.getValue(PREFIX_PERSON_ID).get());
-            noteId = Integer.parseInt(argMultimap.getValue(PREFIX_NOTE_ID).get());
-        } catch (NumberFormatException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_INTEGER_ARGUMENT, e.getMessage()));
-        }
+
+        ContactID contactId = ParserUtil.parseContactID(argMultimap.getValue(PREFIX_PERSON_ID).get());
+        NoteID noteId = ParserUtil.parseNoteID(argMultimap.getValue(PREFIX_NOTE_ID).get());
 
         return new DeleteNoteCommand(contactId, noteId);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -19,6 +19,9 @@ import seedu.address.model.event.EventInformation;
 import seedu.address.model.event.EventLocation;
 import seedu.address.model.event.EventName;
 import seedu.address.model.event.EventTime;
+import seedu.address.model.note.NoteContent;
+import seedu.address.model.note.NoteID;
+import seedu.address.model.note.NoteTitle;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.ContactID;
 import seedu.address.model.person.Email;
@@ -154,6 +157,56 @@ public class ParserUtil {
         return result;
     }
 
+    /**
+     * Parses a {@code String noteTitle} into a {@code NoteTitle}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code noteTitle} is invalid.
+     */
+    public static NoteTitle parseNoteTitle(String noteTitle) throws ParseException {
+        requireNonNull(noteTitle);
+        String trimmedNoteTitle = noteTitle.trim();
+        if (!NoteTitle.isValidNoteTitle(trimmedNoteTitle)) {
+            throw new ParseException(NoteTitle.MESSAGE_CONSTRAINTS);
+        }
+        return NoteTitle.fromString(trimmedNoteTitle);
+    }
+
+    /**
+     * Parses a {@code String noteContent} into a {@code NoteContent}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code noteContent} is invalid.
+     */
+    public static NoteContent parseNoteContent(String noteContent) throws ParseException {
+        requireNonNull(noteContent);
+        String trimmedNoteContent = noteContent.trim();
+        if (!NoteContent.isValidNoteContent(trimmedNoteContent)) {
+            throw new ParseException(NoteContent.MESSAGE_CONSTRAINTS);
+        }
+        return NoteContent.fromString(trimmedNoteContent);
+    }
+
+    /**
+     * Parses a {@code String noteID} into a {@code NoteID}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code noteID} is invalid.
+     */
+    public static NoteID parseNoteID(String noteID) throws ParseException {
+        requireNonNull(noteID);
+        String trimmedNoteID = noteID.trim();
+        if (trimmedNoteID.isEmpty()) {
+            throw new ParseException(NoteID.MESSAGE_NON_EMPTY);
+        }
+        NoteID result = null;
+        try {
+            result = NoteID.fromString(trimmedNoteID);
+        } catch (NumberFormatException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_INTEGER_ARGUMENT, e.getMessage()));
+        }
+        return result;
+    }
 
     /**
      * Parses a {@code String eventName} into a {@code EventName}.

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -1,5 +1,7 @@
 package seedu.address.model.note;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
 /**
  * Represents a Note.
  */
@@ -9,6 +11,17 @@ public class Note {
 
     /**
      * Constructs a Note.
+     * @param title The title of the note.
+     * @param content The content of the note.
+     */
+    public Note(NoteTitle title, NoteContent content) {
+        requireAllNonNull(title, content);
+        this.title = title;
+        this.content = content;
+    }
+
+    /**
+     * Constructs a Note from string representation.
      * @param title The title of the note.
      * @param content The content of the note.
      */

--- a/src/main/java/seedu/address/model/note/NoteContent.java
+++ b/src/main/java/seedu/address/model/note/NoteContent.java
@@ -1,12 +1,24 @@
 package seedu.address.model.note;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 /**
  * Represents a Note's content.
  */
 public class NoteContent {
+    public static final String MESSAGE_CONSTRAINTS = "Note content should not be blank";
+    /*
+     * The first character of the note content must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
     private final String content;
 
     private NoteContent(String content) {
+        requireNonNull(content);
+        checkArgument(isValidNoteContent(content), MESSAGE_CONSTRAINTS);
         this.content = content;
     }
 
@@ -16,6 +28,15 @@ public class NoteContent {
      */
     public static NoteContent fromString(String content) {
         return new NoteContent(content);
+    }
+
+    /**
+     * Returns true if a given string is a valid note content.
+     * @param test The string to be tested.
+     * @return A boolean indicating whether the string is valid.
+     */
+    public static boolean isValidNoteContent(String test) {
+        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/note/NoteID.java
+++ b/src/main/java/seedu/address/model/note/NoteID.java
@@ -1,0 +1,68 @@
+package seedu.address.model.note;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents the note id for DeleteEventCommand
+ */
+public class NoteID {
+    public static final String MESSAGE_NON_EMPTY = "Note ID should not be blank";
+
+    private final int id;
+
+    private NoteID(String id) {
+        requireNonNull(id);
+        this.id = Integer.parseInt(id);
+    }
+
+    private NoteID(int id) {
+        requireNonNull(id);
+        this.id = id;
+    }
+
+    /**
+     * Gets the numerical id
+     * @return The numerical id
+     */
+    public int getId() {
+        return this.id;
+    }
+
+    /**
+     * Constructs an {@code NoteID} object from {@code String}
+     * @param id The id in {@code String}
+     * @return The {@code NoteID} object
+     */
+    public static NoteID fromString(String id) {
+        return new NoteID(id);
+    }
+
+    /**
+     * Constructs an {@code NoteID} object from {@code int}
+     * @param id The id in {@code int}
+     * @return The {@code NoteID} object
+     */
+    public static NoteID fromInt(int id) {
+        return new NoteID(id);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof NoteID)) {
+            return false;
+        }
+
+        NoteID otherNoteID = (NoteID) other;
+        return id == otherNoteID.id;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(this.id);
+    }
+}

--- a/src/main/java/seedu/address/model/note/NoteTitle.java
+++ b/src/main/java/seedu/address/model/note/NoteTitle.java
@@ -1,12 +1,24 @@
 package seedu.address.model.note;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 /**
  * Represents a Note's title.
  */
 public class NoteTitle {
+    public static final String MESSAGE_CONSTRAINTS = "Note title should not be blank";
+    /*
+     * The first character of the note title must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
     private final String title;
 
     private NoteTitle(String title) {
+        requireNonNull(title);
+        checkArgument(isValidNoteTitle(title), MESSAGE_CONSTRAINTS);
         this.title = title;
     }
 
@@ -16,6 +28,15 @@ public class NoteTitle {
      */
     public static NoteTitle fromString(String title) {
         return new NoteTitle(title);
+    }
+
+    /**
+     * Returns true if a given string is a valid note title.
+     * @param test The string to be tested.
+     * @return A boolean indicating whether the string is valid.
+     */
+    public static boolean isValidNoteTitle(String test) {
+        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/ContactID.java
+++ b/src/main/java/seedu/address/model/person/ContactID.java
@@ -42,4 +42,19 @@ public class ContactID {
     public String toString() {
         return String.valueOf(this.id);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ContactID)) {
+            return false;
+        }
+
+        ContactID otherContactID = (ContactID) other;
+        return id == otherContactID.id;
+    }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -14,6 +14,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.EventID;
 import seedu.address.model.note.Note;
+import seedu.address.model.note.NoteID;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -103,18 +104,18 @@ public class Person {
     /**
      * Remove a note by its user-friendly id
      * @param id The id of the note you want to remove
-     * @return {@code true} if the operation is successful and {@code false} if the note with this id does not exist
+     * @return The note object that is just deleted if the operation is successful
+     *      or {@code null} if the note with this name does not exist
      */
-    public boolean removeNoteByUserFriendlyId(int id) {
-        return this.removeNoteByIndex(id - 1);
+    public Note removeNoteByUserFriendlyId(NoteID id) {
+        return this.removeNoteByIndex(id.getId() - 1);
     }
 
-    private boolean removeNoteByIndex(int index) {
+    private Note removeNoteByIndex(int index) {
         if (index < 0 || index >= this.notes.size()) {
-            return false;
+            return null;
         }
-        this.notes.remove(index);
-        return true;
+        return this.notes.remove(index);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddNoteCommandTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.note.Note;
+import seedu.address.model.person.ContactID;
 
 public class AddNoteCommandTest {
 
@@ -35,16 +36,16 @@ public class AddNoteCommandTest {
 
     @Test
     public void execute_correctCommand_success() throws CommandException {
-        int personId = 1;
-        assertCommandSuccessWithFeedback(() -> new AddNoteCommand(personId, VALID_NOTE_0)
+        ContactID contactId = ContactID.fromInt(1);
+        assertCommandSuccessWithFeedback(() -> new AddNoteCommand(contactId, VALID_NOTE_0)
                 .execute(model), AddNoteCommand.MESSAGE_SUCCESS + VALID_NOTE_0.getTitle());
     }
 
     @Test
     public void execute_personNotExist_fails() throws CommandException {
-        int personId = 99999;
-        assertCommandFailWithFeedback(() -> new AddNoteCommand(personId, VALID_NOTE_SAME_TITLE_0)
-                .execute(model), AddNoteCommand.MESSAGE_PERSON_NOT_FOUND + personId);
+        ContactID contactId = ContactID.fromInt(99999);
+        assertCommandFailWithFeedback(() -> new AddNoteCommand(contactId, VALID_NOTE_SAME_TITLE_0)
+                .execute(model), AddNoteCommand.MESSAGE_PERSON_NOT_FOUND + contactId);
     }
 
     private void assertCommandSuccessWithFeedback(ThrowingSupplier<CommandResult> function, String result) {
@@ -72,14 +73,14 @@ public class AddNoteCommandTest {
     public void equals() {
         Note noteA = NOTE_A;
         Note noteB = NOTE_B;
-        AddNoteCommand addNoteACommand = new AddNoteCommand(Integer.parseInt(VALID_NOTE_A_PERSON_ID), noteA);
-        AddNoteCommand addNoteBCommand = new AddNoteCommand(Integer.parseInt(VALID_NOTE_B_PERSON_ID), noteB);
+        AddNoteCommand addNoteACommand = new AddNoteCommand(ContactID.fromString(VALID_NOTE_A_PERSON_ID), noteA);
+        AddNoteCommand addNoteBCommand = new AddNoteCommand(ContactID.fromString(VALID_NOTE_B_PERSON_ID), noteB);
 
         // same object -> returns true
         assertTrue(addNoteACommand.equals(addNoteACommand));
 
         // same values -> returns true
-        AddNoteCommand addNoteACommandCopy = new AddNoteCommand(Integer.parseInt(VALID_NOTE_A_PERSON_ID), noteA);
+        AddNoteCommand addNoteACommandCopy = new AddNoteCommand(ContactID.fromString(VALID_NOTE_A_PERSON_ID), noteA);
         assertTrue(addNoteACommand.equals(addNoteACommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.note.Note;
+import seedu.address.model.note.NoteID;
 import seedu.address.model.person.ContactID;
 
 public class DeleteNoteCommandTest {
@@ -34,25 +35,27 @@ public class DeleteNoteCommandTest {
     @Test
     public void execute_correctCommand_success() throws CommandException {
         ContactID contactId = ContactID.fromInt(1);
+        NoteID noteId = NoteID.fromInt(1);
         model.findPersonByUserFriendlyId(contactId).addNote(VALID_NOTE_0);
-        assertCommandSuccessWithFeedback(() -> new DeleteNoteCommand(contactId.getId(), 1)
-                .execute(model), DeleteNoteCommand.MESSAGE_SUCCESS + "1");
+        assertCommandSuccessWithFeedback(() -> new DeleteNoteCommand(contactId, noteId)
+                .execute(model), DeleteNoteCommand.MESSAGE_SUCCESS + "1. Meeting Topics");
     }
 
     @Test
     public void execute_personNotFound_fails() throws CommandException {
-        int personId = 999;
-        assertCommandFailWithFeedback(() -> new DeleteNoteCommand(personId, 1)
-                .execute(model), DeleteNoteCommand.MESSAGE_PERSON_NOT_FOUND + personId);
+        ContactID contactId = ContactID.fromInt(999);
+        NoteID noteId = NoteID.fromInt(1);
+        assertCommandFailWithFeedback(() -> new DeleteNoteCommand(contactId, noteId)
+                .execute(model), DeleteNoteCommand.MESSAGE_PERSON_NOT_FOUND + contactId.getId());
     }
 
     @Test
     public void execute_noteNotFound_fails() throws CommandException {
         ContactID contactId = ContactID.fromInt(1);
-        int invalidNoteId = 99999;
+        NoteID invalidNoteId = NoteID.fromInt(99999);
         model.findPersonByUserFriendlyId(contactId).addNote(VALID_NOTE_0);
-        assertCommandFailWithFeedback(() -> new DeleteNoteCommand(contactId.getId(), invalidNoteId)
-                .execute(model), DeleteNoteCommand.MESSAGE_NOTE_NOT_FOUND + invalidNoteId);
+        assertCommandFailWithFeedback(() -> new DeleteNoteCommand(contactId, invalidNoteId)
+                .execute(model), DeleteNoteCommand.MESSAGE_NOTE_NOT_FOUND + invalidNoteId.getId());
     }
 
     private void assertCommandSuccessWithFeedback(ThrowingSupplier<CommandResult> function, String result) {
@@ -78,17 +81,17 @@ public class DeleteNoteCommandTest {
 
     @Test
     public void equals() {
-        DeleteNoteCommand deleteNoteACommand = new DeleteNoteCommand(Integer.parseInt(VALID_NOTE_A_PERSON_ID),
-                Integer.parseInt(VALID_NOTE_A_NOTE_ID));
-        DeleteNoteCommand deleteNoteBCommand = new DeleteNoteCommand(Integer.parseInt(VALID_NOTE_B_PERSON_ID),
-                Integer.parseInt(VALID_NOTE_B_NOTE_ID));
+        DeleteNoteCommand deleteNoteACommand = new DeleteNoteCommand(ContactID.fromString(VALID_NOTE_A_PERSON_ID),
+                NoteID.fromString(VALID_NOTE_A_NOTE_ID));
+        DeleteNoteCommand deleteNoteBCommand = new DeleteNoteCommand(ContactID.fromString(VALID_NOTE_B_PERSON_ID),
+                NoteID.fromString(VALID_NOTE_B_NOTE_ID));
 
         // same object -> returns true
         assertTrue(deleteNoteACommand.equals(deleteNoteACommand));
 
         // same values -> returns true
-        DeleteNoteCommand deleteNoteACommandCopy = new DeleteNoteCommand(Integer.parseInt(VALID_NOTE_A_PERSON_ID),
-                Integer.parseInt(VALID_NOTE_A_NOTE_ID));
+        DeleteNoteCommand deleteNoteACommandCopy = new DeleteNoteCommand(ContactID.fromString(VALID_NOTE_A_PERSON_ID),
+                NoteID.fromString(VALID_NOTE_A_NOTE_ID));
         assertTrue(deleteNoteACommand.equals(deleteNoteACommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddNoteCommand;
 import seedu.address.model.note.Note;
+import seedu.address.model.person.ContactID;
 
 public class AddNoteCommandParserTest {
     private AddNoteCommandParser parser = new AddNoteCommandParser();
@@ -34,7 +35,7 @@ public class AddNoteCommandParserTest {
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NOTE_A_PERSON_ID_DESC + NOTE_A_TITLE_DESC
                 + NOTE_A_CONTENT_DESC,
-                new AddNoteCommand(Integer.parseInt(VALID_NOTE_A_PERSON_ID), expectedNote));
+                new AddNoteCommand(ContactID.fromString(VALID_NOTE_A_PERSON_ID), expectedNote));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteNoteCommandParserTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteNoteCommand;
+import seedu.address.model.note.NoteID;
+import seedu.address.model.person.ContactID;
 
 public class DeleteNoteCommandParserTest {
     private DeleteNoteCommandParser parser = new DeleteNoteCommandParser();
@@ -25,8 +27,8 @@ public class DeleteNoteCommandParserTest {
     public void parse_allFieldsPresent_success() {
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NOTE_A_PERSON_ID_DESC + NOTE_A_NOTE_ID_DESC,
-                new DeleteNoteCommand(Integer.parseInt(VALID_NOTE_A_PERSON_ID),
-                        Integer.parseInt(VALID_NOTE_A_NOTE_ID)));
+                new DeleteNoteCommand(ContactID.fromString(VALID_NOTE_A_PERSON_ID),
+                        NoteID.fromString(VALID_NOTE_A_NOTE_ID)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -22,6 +22,9 @@ import seedu.address.model.event.EventInformation;
 import seedu.address.model.event.EventLocation;
 import seedu.address.model.event.EventName;
 import seedu.address.model.event.EventTime;
+import seedu.address.model.note.NoteContent;
+import seedu.address.model.note.NoteID;
+import seedu.address.model.note.NoteTitle;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.ContactID;
 import seedu.address.model.person.Email;
@@ -35,6 +38,10 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_CONTACT_ID_1 = "abc";
+    private static final String INVALID_CONTACT_ID_2 = "1.23";
+    private static final String INVALID_NOTE_ID_1 = "abc";
+    private static final String INVALID_NOTE_ID_2 = "1.23";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -42,8 +49,13 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_CONTACT_ID = "1";
+    private static final String VALID_NOTE_ID = "1";
+    private static final String VALID_NOTE_CONTENT = "Content 1";
+    private static final String VALID_NOTE_TITLE = "Title 1";
 
     private static final String WHITESPACE = " \t\r\n";
+    private static final String EMPTY_STRING = "";
 
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
@@ -204,21 +216,88 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseContactID_success() throws Exception {
-        assertEquals("1", ParserUtil.parseContactID("1").toString());
+    public void parseContactID_validValue_returnsContactID() throws Exception {
+        assertEquals(VALID_CONTACT_ID, ParserUtil.parseContactID(VALID_CONTACT_ID).toString());
     }
 
     @Test
-    public void parseContactID_fail_emptyString() {
+    public void parseContactID_invalidValueEmptyString_throwsParseException() {
         assertThrows(ParseException.class, ContactID.MESSAGE_NON_EMPTY, () -> ParserUtil.parseContactID("").toString());
     }
 
     @Test
-    public void parseContactID_fail_invalidInteger() {
-        assertThrows(ParseException.class, String.format(Messages.MESSAGE_INVALID_INTEGER_ARGUMENT,
-                "For input string: \"abc\""), () -> ParserUtil.parseContactID("abc").toString());
-        assertThrows(ParseException.class, String.format(Messages.MESSAGE_INVALID_INTEGER_ARGUMENT,
-                "For input string: \"1.23\""), () -> ParserUtil.parseContactID("1.23").toString());
+    public void parseContactID_invalidInteger_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseContactID(INVALID_CONTACT_ID_1));
+        assertThrows(ParseException.class, () -> ParserUtil.parseContactID(INVALID_CONTACT_ID_2));
+    }
+
+    @Test
+    public void parseNoteID_validValue_returnsNoteID() throws Exception {
+        assertEquals(VALID_NOTE_ID, ParserUtil.parseNoteID(VALID_NOTE_ID).toString());
+    }
+
+    @Test
+    public void parseNoteID_invalidValueEmptyString_throwsParseException() {
+        assertThrows(ParseException.class,
+                NoteID.MESSAGE_NON_EMPTY, () -> ParserUtil.parseNoteID(EMPTY_STRING).toString());
+    }
+
+    @Test
+    public void parseNoteID_invalidValueWhitespace_throwsParseException() {
+        assertThrows(ParseException.class,
+                NoteID.MESSAGE_NON_EMPTY, () -> ParserUtil.parseNoteID(WHITESPACE).toString());
+    }
+
+    @Test
+    public void parseNoteID_invalidValueNotInteger_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseNoteID(INVALID_NOTE_ID_1).toString());
+        assertThrows(ParseException.class, () -> ParserUtil.parseNoteID(INVALID_NOTE_ID_2).toString());
+    }
+
+    @Test
+    public void parseNoteContent_validValueWithoutWhitespace_returnsNoteContent() throws Exception {
+        assertEquals(VALID_NOTE_CONTENT, ParserUtil.parseNoteContent(VALID_NOTE_CONTENT).toString());
+    }
+
+    @Test
+    public void parseNoteContent_validValueWithWhitespace_returnsTrimmedNoteContent() throws Exception {
+        String noteContentWithWhitespace = WHITESPACE + VALID_NOTE_CONTENT + WHITESPACE;
+        assertEquals(VALID_NOTE_CONTENT, ParserUtil.parseNoteContent(noteContentWithWhitespace).toString());
+    }
+
+    @Test
+    public void parseNoteContent_invalidValueEmptyString_throwsParseException() throws Exception {
+        assertThrows(ParseException.class, NoteContent.MESSAGE_CONSTRAINTS, () ->
+                ParserUtil.parseNoteContent(EMPTY_STRING).toString());
+    }
+
+    @Test
+    public void parseNoteContent_invalidValueWhitespace_throwsParseException() throws Exception {
+        assertThrows(ParseException.class, NoteContent.MESSAGE_CONSTRAINTS, () ->
+                ParserUtil.parseNoteContent(WHITESPACE).toString());
+    }
+
+    @Test
+    public void parseNoteTitle_validValueWithoutWhitespace_returnsNoteTitle() throws Exception {
+        assertEquals(VALID_NOTE_TITLE, ParserUtil.parseNoteContent(VALID_NOTE_TITLE).toString());
+    }
+
+    @Test
+    public void parseNoteTitle_validValueWithWhitespace_returnsTrimmedNoteTitle() throws Exception {
+        String noteTitleWithWhitespace = WHITESPACE + VALID_NOTE_TITLE + WHITESPACE;
+        assertEquals(VALID_NOTE_TITLE, ParserUtil.parseNoteTitle(noteTitleWithWhitespace).toString());
+    }
+
+    @Test
+    public void parseNoteTitle_invalidValueEmptyString_throwsParseException() throws Exception {
+        assertThrows(ParseException.class, NoteTitle.MESSAGE_CONSTRAINTS, () ->
+                ParserUtil.parseNoteTitle(EMPTY_STRING).toString());
+    }
+
+    @Test
+    public void parseNoteTitle_invalidValueWhitespace_throwsParseException() throws Exception {
+        assertThrows(ParseException.class, NoteTitle.MESSAGE_CONSTRAINTS, () ->
+                ParserUtil.parseNoteTitle(WHITESPACE).toString());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/note/NoteContentTest.java
+++ b/src/test/java/seedu/address/model/note/NoteContentTest.java
@@ -2,10 +2,37 @@ package seedu.address.model.note;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 public class NoteContentTest {
+
+    @Test
+    public void fromString_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> NoteContent.fromString(null));
+    }
+
+    @Test
+    public void fromString_invalidNoteContent_throwsIllegalArgumentException() {
+        String invalidNoteContent = "";
+        assertThrows(IllegalArgumentException.class, () -> NoteContent.fromString(invalidNoteContent));
+    }
+
+    @Test
+    public void isValidNoteContent() {
+        // null note content
+        assertThrows(NullPointerException.class, () -> NoteContent.isValidNoteContent(null));
+
+        // invalid note contents
+        assertFalse(NoteContent.isValidNoteContent("")); // empty string
+        assertFalse(NoteContent.isValidNoteContent(" ")); // spaces only
+
+        // valid note contents
+        assertTrue(NoteContent.isValidNoteContent("note content"));
+        assertTrue(NoteContent.isValidNoteContent("-")); // one character
+    }
+
     @Test
     public void equals() {
         NoteContent content = NoteContent.fromString("Valid Note Content");

--- a/src/test/java/seedu/address/model/note/NoteIdTest.java
+++ b/src/test/java/seedu/address/model/note/NoteIdTest.java
@@ -1,0 +1,38 @@
+package seedu.address.model.note;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class NoteIdTest {
+
+    @Test
+    public void fromString_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> NoteID.fromString(null));
+    }
+
+    @Test
+    public void equals() {
+        NoteID id = NoteID.fromString("1");
+
+        // same values -> returns true
+        assertTrue(id.equals(NoteID.fromString("1")));
+
+        // same object -> returns true
+        assertTrue(id.equals(id));
+
+        // same values but using fromInt method -> returns true
+        assertTrue(id.equals(NoteID.fromInt(1)));
+
+        // null -> returns false
+        assertFalse(id.equals(null));
+
+        // different types -> returns false
+        assertFalse(id.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(id.equals(NoteID.fromString("2")));
+    }
+}

--- a/src/test/java/seedu/address/model/note/NoteTitleTest.java
+++ b/src/test/java/seedu/address/model/note/NoteTitleTest.java
@@ -2,10 +2,37 @@ package seedu.address.model.note;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 public class NoteTitleTest {
+
+    @Test
+    public void fromString_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> NoteTitle.fromString(null));
+    }
+
+    @Test
+    public void fromString_invalidNoteTitle_throwsIllegalArgumentException() {
+        String invalidNoteTitle = "";
+        assertThrows(IllegalArgumentException.class, () -> NoteTitle.fromString(invalidNoteTitle));
+    }
+
+    @Test
+    public void isValidNoteTitle() {
+        // null note title
+        assertThrows(NullPointerException.class, () -> NoteTitle.isValidNoteTitle(null));
+
+        // invalid note title
+        assertFalse(NoteTitle.isValidNoteTitle("")); // empty string
+        assertFalse(NoteTitle.isValidNoteTitle(" ")); // spaces only
+
+        // valid note title
+        assertTrue(NoteTitle.isValidNoteTitle("note title"));
+        assertTrue(NoteTitle.isValidNoteTitle("-")); // one character
+    }
+
     @Test
     public void equals() {
         NoteTitle title = NoteTitle.fromString("Valid Note Title");


### PR DESCRIPTION
Fix the bug that accepts empty string or a string with only whitespaces as command argument in add note and delete note commands.