### PR TITLE
Not allowing null in EventTime and fix the bug of deleting contact lead to ghost events

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -200,6 +200,8 @@ Adds an event to a contact. The added event should not have clashes in timing wi
 
 Format: `add event -id CONTACT_ID -en EVENT_NAME -st START_TIME [-et END_TIME] [-loc LOCATION] [-info INFORMATION]`
 
+(If start time is exactly equals to end time, the end time for the event will not be displayed when outputting the event to text-based UI)
+
 Date-Time Format:
  - You can use one of the following formats for `START_TIME` and `END_TIME`:
     - Both date and time: `yyyy-MM-dd HH:mm[:ss]`

--- a/src/main/java/seedu/address/logic/commands/ListEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListEventCommand.java
@@ -38,8 +38,8 @@ public class ListEventCommand extends ListCommand {
      *     {@code false} in descending order.
      */
     public ListEventCommand(EventTime filterStartTime, EventTime filterEndTime, boolean sortAscending) {
-        this.filterStartTime = filterStartTime.getTime();
-        this.filterEndTime = filterEndTime.getTime();
+        this.filterStartTime = filterStartTime != null ? filterStartTime.getTime() : null;
+        this.filterEndTime = filterEndTime != null ? filterEndTime.getTime() : null;
         this.sortAscending = sortAscending;
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
@@ -40,8 +40,10 @@ public class AddEventCommandParser implements Parser<AddEventCommand> {
                 PREFIX_EVENT_INFORMATION);
 
         EventName eventName = ParserUtil.parseEventName(argMultimap.getValue(PREFIX_EVENT_NAME).get());
-        EventTime startTime = ParserUtil.parseEventTime(argMultimap.getValue(PREFIX_START_TIME).get());
-        EventTime endTime = ParserUtil.parseEventTime(argMultimap.getValue(PREFIX_END_TIME).orElseGet(()->null));
+        String startTimeStr = argMultimap.getValue(PREFIX_START_TIME).get();
+        EventTime startTime = ParserUtil.parseEventTime(startTimeStr);
+        EventTime endTime = ParserUtil.parseEventTime(argMultimap.getValue(PREFIX_END_TIME)
+                .orElseGet(()->startTimeStr));
         EventLocation location =
                 ParserUtil.parseEventLocation(argMultimap.getValue(PREFIX_EVENT_LOCATION).orElseGet(()->null));
         EventInformation information =

--- a/src/main/java/seedu/address/logic/parser/ListEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListEventCommandParser.java
@@ -33,14 +33,19 @@ public class ListEventCommandParser implements Parser<ListEventCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_START_TIME, PREFIX_END_TIME, PREFIX_SORT_DESCENDING);
 
-        EventTime filterStartTime = ParserUtil.parseEventTime(argMultimap.getValue(PREFIX_START_TIME)
-                .orElseGet(()->null));
-        EventTime filterEndTime = ParserUtil.parseEventTime(argMultimap.getValue(PREFIX_END_TIME).orElseGet(()->null));
+        EventTime filterStartTime = ParserUtil.arePrefixesPresent(argMultimap, PREFIX_START_TIME)
+                ? ParserUtil.parseEventTime(argMultimap.getValue(PREFIX_START_TIME).get())
+                : null;
+        EventTime filterEndTime = ParserUtil.arePrefixesPresent(argMultimap, PREFIX_END_TIME)
+                ? ParserUtil.parseEventTime(argMultimap.getValue(PREFIX_END_TIME).get())
+                : null;
 
         boolean useAscendingOrder = !ParserUtil.arePrefixesPresent(argMultimap, PREFIX_SORT_DESCENDING);
-
-        if (filterStartTime.isAfter(filterEndTime)) {
-            throw new ParseException(String.format(MESSAGE_START_TIME_AFTER_END_TIME, filterStartTime, filterEndTime));
+        if (filterStartTime != null) {
+            if (filterStartTime.isAfter(filterEndTime)) {
+                throw new ParseException(String.format(MESSAGE_START_TIME_AFTER_END_TIME,
+                        filterStartTime, filterEndTime));
+            }
         }
         return new ListEventCommand(filterStartTime, filterEndTime, useAscendingOrder);
     }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -127,6 +127,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * {@code key} must exist in the address book.
      */
     public void removePerson(Person key) {
+        key.getEvents().forEach(this.allEvents::remove);
         persons.remove(key);
     }
 

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -111,7 +111,7 @@ public class Event {
      */
     public String getUiText() {
         String result = this.getName() + "\nStarts at: " + this.start;
-        if (!this.end.toString().isEmpty()) {
+        if (!this.end.equals(this.start)) {
             result += "\nEnds at: " + this.end;
         }
         if (!this.location.toString().isEmpty()) {

--- a/src/main/java/seedu/address/model/event/EventTime.java
+++ b/src/main/java/seedu/address/model/event/EventTime.java
@@ -14,9 +14,6 @@ public class EventTime {
 
     private final LocalDateTime time;
 
-    private EventTime() {
-        this.time = null;
-    }
     private EventTime(String time) throws DateTimeParseException {
         this.time = DateTimeUtil.parseString(time);
     }
@@ -27,7 +24,7 @@ public class EventTime {
      * @return The {@code EventTime} object
      */
     public static EventTime fromString(String timeStr) throws DateTimeParseException {
-        return timeStr.isEmpty() ? new EventTime() : new EventTime(timeStr);
+        return new EventTime(timeStr);
     }
 
     /**
@@ -58,8 +55,8 @@ public class EventTime {
             return false;
         }
 
-        EventTime otherName = (EventTime) other;
-        return time.equals(otherName.time);
+        EventTime otherTime = (EventTime) other;
+        return time.equals(otherTime.time);
     }
 
     /**

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -165,20 +165,14 @@ public class UniqueEventList implements Iterable<Event> {
         LocalDateTime newEventEndTime = newEvent.getEndTime();
 
         assert newEventStartTime != null : "Start time should not be null";
-
-        if (newEventEndTime == null) {
-            newEventEndTime = newEventStartTime;
-        }
+        assert newEventEndTime != null : "End time should not be null";
 
         for (Event e : this.internalList) {
             LocalDateTime startTime = e.getStartTime();
             LocalDateTime endTime = e.getEndTime();
 
             assert startTime != null : "Start time should not be null";
-
-            if (endTime == null) {
-                endTime = startTime;
-            }
+            assert endTime != null : "End time should not be null";
 
             if (DateTimeUtil.timeIntervalsOverlap(newEventStartTime, newEventEndTime, startTime, endTime)) {
                 return e;

--- a/src/test/java/seedu/address/logic/commands/ListEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListEventCommandTest.java
@@ -33,8 +33,8 @@ public class ListEventCommandTest {
         model.findPersonByUserFriendlyId(ContactID.fromInt(1)).addEvent(VALID_EVENT_0);
         model.findPersonByUserFriendlyId(ContactID.fromInt(2)).addEvent(VALID_EVENT_1);
         model.findPersonByUserFriendlyId(ContactID.fromInt(2)).addEvent(VALID_EVENT_2);
-        assertCommandSuccess(() -> new ListEventCommand(EventTime.fromString(""),
-                EventTime.fromString(""), true).execute(model));
+        assertCommandSuccess(() -> new ListEventCommand(null,
+                null, true).execute(model));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -337,8 +337,6 @@ public class ParserUtilTest {
                 ParserUtil.parseEventTime("2023-12-01").toString());
         assertEquals("2023-12-01 10:02:03",
                 ParserUtil.parseEventTime("2023-12-01 10:02:03").toString());
-        assertEquals("",
-                ParserUtil.parseEventTime(null).toString());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/event/EventTimeTest.java
+++ b/src/test/java/seedu/address/model/event/EventTimeTest.java
@@ -1,7 +1,9 @@
 package seedu.address.model.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -11,6 +13,9 @@ import org.junit.jupiter.api.Test;
 public class EventTimeTest {
     @Test
     public void test_eventTimeEquals_pass() {
+        EventTime instance = EventTime.fromString("2023-11-03 00:30:00");
+        assertTrue(instance.equals(instance));
+        assertFalse(instance.equals(new Object()));
         assertEquals(EventTime.fromString("2023-11-02 00:30:00"),
                 EventTime.fromString("2023-11-02 00:30:00"));
         assertEquals(EventTime.fromString("00:30:00"),


### PR DESCRIPTION
 - Not allowing `null` in field `EventTime.time` anymore.
 - Fix the bug of deleting contact does not remove events in the global event list, thus causing ghost events
   - Test it with:
  ```
add event -id 1 -en sdfgs -st 2012-10-10
delete contact 1
add event -id 1 -en sdfgs -st 2012-10-10
list events -st 2012-10-10 -et 2032-10-10
```

Other changes:
 - Remove the unnecessary logic in `UniqueEventList::getOverlappingEvent` since in `AddEventCommand`, end time is set to start time if user does not specify an end time
 - Change the logic in `Event::getUiText` so that when start time equals to end time, end time will be hidden (also add this information to UG)