### PR TITLE
Fix: UI now updates when tag is updated

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -134,7 +134,7 @@ Examples:
 
 ### Adding tags : `add tag`
 
-Adds one or more tags to a contact.
+Adds one or more tags to a contact. Contact list will go back to showing all contacts upon successful addition.
 
 Format: `add tag -id CONTACT_ID -t TAGNAME...`
 
@@ -151,7 +151,7 @@ Examples:
 
 ### Deleting tags : `delete tag`
 
-Deletes one or more tags to a contact. 
+Deletes one or more tags to a contact. Contact list will go back to showing all contacts upon successful deletion.
 
 Format: `delete tag -id CONTACT_ID -t TAGNAME...`
 

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -42,7 +42,10 @@ public class AddTagCommand extends AddCommand {
         if (person == null) {
             throw new CommandException(MESSAGE_PERSON_NOT_FOUND + this.contactId);
         }
-        person.addTags(this.toAdd);
+        
+        Person toEdit = person;
+        toEdit.addTags(this.toAdd);
+        model.setPerson(person, toEdit);
 
         final StringBuilder builder = new StringBuilder();
         builder.append(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -42,7 +42,7 @@ public class AddTagCommand extends AddCommand {
         if (person == null) {
             throw new CommandException(MESSAGE_PERSON_NOT_FOUND + this.contactId);
         }
-        
+
         Person toEdit = person;
         toEdit.addTags(this.toAdd);
         model.setPerson(person, toEdit);

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -41,7 +41,10 @@ public class DeleteTagCommand extends DeleteCommand {
         if (person == null) {
             throw new CommandException(MESSAGE_PERSON_NOT_FOUND + this.contactId);
         }
-        person.removeTags(toDelete);
+
+        Person toEdit = person;
+        toEdit.removeTags(this.toDelete);
+        model.setPerson(person, toEdit);
 
         final StringBuilder builder = new StringBuilder();
         builder.append(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -116,8 +116,8 @@ public class ModelManager implements Model {
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
-
         addressBook.setPerson(target, editedPerson);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     //=========== Filtered Person List Accessors =============================================================


### PR DESCRIPTION
The issue is caused because `FlowPane` (the container we use to store tag labels) doesn't have a given factory that takes in a callback method, thus it doesn't auto-update. 

However, since `TableView` (the container we use for listing all contacts) has this, I made a workaround where instead of just adding to the current person, the tag update methods will actually create a copy of the object we want to edit, modify the tag in that copy, and set the person in the list.

We're using the already existing `setPerson` method in the AB3 model, which I modify a bit, so that everytime that method is called (only add tag and delete tag calls the method), the list will go back to showing all contacts. This is to avoid any cases where the list is supposed to show contacts containing a given tag which the tag modification procedure may mess up. The nature of the value observer should guard against this, but I did it just in case. Let me know if y'all think that we should do otherwise.  