### PR TITLE
Date bugs

### DIFF
--- a/src/main/java/seedu/address/commons/util/DateTimeUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateTimeUtil.java
@@ -3,7 +3,9 @@ package seedu.address.commons.util;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
@@ -20,10 +22,13 @@ public class DateTimeUtil {
      */
     public static LocalDateTime parseString(String str) throws DateTimeParseException {
         requireNonNull(str);
-        
+
         DateTimeFormatter formatter1 = DateTimeFormatter
                 .ofPattern("uuuu-MM-dd HH:mm[:ss]")
                 .withResolverStyle(ResolverStyle.STRICT);
+
+        DateTimeFormatter onlyDateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        DateTimeFormatter onlyTimeFormatter = DateTimeFormatter.ofPattern("HH:mm[:ss]");
 
         LocalDateTime result = null;
 
@@ -31,10 +36,17 @@ public class DateTimeUtil {
             result = LocalDateTime.parse(str, formatter1);
         } catch (DateTimeParseException e2) {
             LocalDateTime now = LocalDateTime.now();
+
             if (str.contains("-")) {
+                // str only contains date, will immediately throw exception otherwise
+                LocalDate onlyDate = LocalDate.parse(str, onlyDateFormatter);
+
                 String appendTime = " 00:00:00";
                 result = LocalDateTime.parse(str + appendTime, formatter1);
             } else {
+                //str only contains time, will immediately throw exception otherwise
+                LocalTime onlyTime = LocalTime.parse(str, onlyTimeFormatter);
+
                 int month = now.getMonthValue();
                 int day = now.getDayOfMonth();
                 String appendDate = now.getYear() + "-" + (month <= 9 ? "0" + month : month)

--- a/src/main/java/seedu/address/commons/util/DateTimeUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateTimeUtil.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 /**
  * Utilities about date and time
@@ -19,8 +20,13 @@ public class DateTimeUtil {
      */
     public static LocalDateTime parseString(String str) throws DateTimeParseException {
         requireNonNull(str);
-        DateTimeFormatter formatter1 = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm[:ss]");
+        
+        DateTimeFormatter formatter1 = DateTimeFormatter
+                .ofPattern("uuuu-MM-dd HH:mm[:ss]")
+                .withResolverStyle(ResolverStyle.STRICT);
+
         LocalDateTime result = null;
+
         try {
             result = LocalDateTime.parse(str, formatter1);
         } catch (DateTimeParseException e2) {

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -349,12 +349,12 @@ public class ParserUtilTest {
         assertThrows(ParseException.class, EventTime.MESSAGE_NON_EMPTY, () -> ParserUtil.parseEventTime(""));
         String dateNow = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         assertThrows(ParseException.class,
-                EventTime.MESSAGE_INVALID_DATETIME_FORMAT + "Text '" + dateNow
-                        + " 1' could not be parsed at index 11", () ->
+                EventTime.MESSAGE_INVALID_DATETIME_FORMAT
+                        + "Text '1' could not be parsed at index 0", () ->
                         ParserUtil.parseEventTime("1"));
         assertThrows(ParseException.class,
-                EventTime.MESSAGE_INVALID_DATETIME_FORMAT + "Text '" + dateNow
-                        + " 1,2,3,4' could not be parsed at index 11", () ->
+                EventTime.MESSAGE_INVALID_DATETIME_FORMAT
+                        + "Text '1,2,3,4' could not be parsed at index 0", () ->
                         ParserUtil.parseEventTime("1,2,3,4"));
     }
 


### PR DESCRIPTION
Two bugs fixed regarding dates:

### Dates 29, 30, and 31 February
The date formatter was changed so that dates 30 and 31 February are not allowed and 29 February is allowed only on leap years.

### Weird error messages
This error messages was because of a mistake in implementing the date string parser.

Before, in the case where the string contains a '-', it doesn't check whether it is in the yyyy-MM-dd format.

This results in weird error messages. For example, when the command is `add event -id 4 -en Hello -st 2022-01-02 100`. This would have an error message "Text '2022-01-02 100 00:00:00" could not be parsed...'. Because, it was previously assumed that a string containing '-' is in the yyyy-MM-dd format, where 00:00:00 will be appended.