### PR TITLE
Fix delete tag feature

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -155,8 +155,7 @@ Deletes one or more tags to a contact. Contact list will go back to showing all 
 
 Format: `delete tag -id CONTACT_ID -t TAGNAME...`
 
-* Deletes one or more tags to a contact, regardless if the tag exists in the contact or not.
-* Duplicates are accepted.
+* Duplicate `TAGNAME` are accepted, but they will be treated as one.
 
 Requirements:
 * `TAGNAME` must be alphanumeric, with no spaces.

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -21,6 +22,7 @@ public class DeleteTagCommand extends DeleteCommand {
             + "Usage:  delete tag -id CONTACT_ID -t TAGNAME...";
     public static final String MESSAGE_PERSON_NOT_FOUND = "Can not find the target contact with ID: ";
     public static final String MESSAGE_SUCCESS = "Successfully deleted tags: ";
+    public static final String MESSAGE_TAGS_DOES_NOT_EXIST = "Could not find the following tags: ";
 
     private final Set<Tag> toDelete;
     private final int contactId;
@@ -43,12 +45,25 @@ public class DeleteTagCommand extends DeleteCommand {
         }
 
         Person toEdit = person;
-        toEdit.removeTags(this.toDelete);
+        Set<Tag> nonExistantTags = new HashSet<>();
+        Set<Tag> existantTags = new HashSet<>();
+        for (Tag t : toDelete) {
+            if (!toEdit.containsTag(t)) {
+                nonExistantTags.add(t);
+            } else {
+                existantTags.add(t);
+            }
+        }
+
+        toEdit.removeTags(existantTags);
         model.setPerson(person, toEdit);
 
         final StringBuilder builder = new StringBuilder();
         builder.append(MESSAGE_SUCCESS);
-        toDelete.forEach(builder::append);
+        existantTags.forEach(builder::append);
+        builder.append("\n");
+        builder.append(MESSAGE_TAGS_DOES_NOT_EXIST);
+        nonExistantTags.forEach(builder::append);
 
         return new CommandResult(builder.toString());
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -34,7 +34,9 @@ public class DeleteTagCommandTest {
         final Set<Tag> tagSet = new TagBuilder().inSet();
 
         assertCommandSuccessWithFeedback(() -> new DeleteTagCommand(personId, tagSet)
-                .execute(model), DeleteTagCommand.MESSAGE_SUCCESS + new TagBuilder().build().toString());
+                .execute(model),
+                DeleteTagCommand.MESSAGE_SUCCESS + "\n"
+                        + DeleteTagCommand.MESSAGE_TAGS_DOES_NOT_EXIST + new TagBuilder().build().toString());
     }
 
     @Test


### PR DESCRIPTION
Previously, non existent tags in a contact were accepted in the `delete tag` command and showed a success message. This behavior has been changed to notifying the user if the tags are non existent. The command will still be executed as usual, with no errors thrown.

![tag fix](https://github.com/AY2324S1-CS2103T-W16-1/tp/assets/139637290/9d87e07a-601d-481d-8493-9a4b9ad08a92)
