### PR TITLE
Fix error messages and help messages

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -31,6 +31,8 @@ import seedu.address.ui.HelpWindow;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_MISSING_SECONDARY_COMMAND =
+            "Please be more specific. Type 'help %1$s' for more details.";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_START_TIME_AFTER_END_TIME = "Start time %s is after the end time %s!\n";
     public static final String MESSAGE_INVALID_INTEGER_ARGUMENT =

--- a/src/main/java/seedu/address/logic/commands/ListEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListEventCommand.java
@@ -23,8 +23,10 @@ public class ListEventCommand extends ListCommand {
     public static final String MESSAGE_DESCENDING = "(in descending order):\n";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + SECONDARY_COMMAND_WORD
-        + " [-descending] [-st filter_start_time] [-et filter_end_time]"
-        + " (-st and -et must either both present or both not present)";
+            + ": Shows a list of all events or events within a specified time interval.\n"
+            + "Usage: " + COMMAND_WORD + " " + SECONDARY_COMMAND_WORD
+            + " [-descending] [-st filter_start_time] [-et filter_end_time]"
+            + " (-st and -et must either both present or both not present)";
 
     private LocalDateTime filterStartTime;
     private LocalDateTime filterEndTime;
@@ -32,10 +34,12 @@ public class ListEventCommand extends ListCommand {
 
     /**
      * Constructor for {@code ListEventCommand} class
+     *
      * @param filterStartTime The start time for filter
-     * @param filterEndTime The end time for filter
-     * @param sortAscending Set to {@code true} to sort the events by start time in ascending order,
-     *     {@code false} in descending order.
+     * @param filterEndTime   The end time for filter
+     * @param sortAscending   Set to {@code true} to sort the events by start time
+     *                        in ascending order,
+     *                        {@code false} in descending order.
      */
     public ListEventCommand(EventTime filterStartTime, EventTime filterEndTime, boolean sortAscending) {
         this.filterStartTime = filterStartTime != null ? filterStartTime.getTime() : null;
@@ -54,8 +58,7 @@ public class ListEventCommand extends ListCommand {
         } else {
             model.updateFilteredEventList(
                     evt -> DateTimeUtil.withinTimeInterval(this.filterStartTime, this.filterEndTime,
-                            evt.getStartTime())
-            );
+                            evt.getStartTime()));
             result = MESSAGE_FILTERED;
         }
         result += this.sortAscending ? MESSAGE_ASCENDING : MESSAGE_DESCENDING;
@@ -65,8 +68,9 @@ public class ListEventCommand extends ListCommand {
             return (startTime1.isBefore(startTime2)
                     ? 1
                     : startTime1.equals(startTime2)
-                    ? 0
-                    : -1) * (sortAscending ? -1 : 1);
+                            ? 0
+                            : -1)
+                    * (sortAscending ? -1 : 1);
         });
         result += StringUtil.eventListToString(eventList);
         return new CommandResult(result, false, true);

--- a/src/main/java/seedu/address/logic/commands/ListPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListPersonCommand.java
@@ -18,10 +18,10 @@ public class ListPersonCommand extends ListCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " "
             + SECONDARY_COMMAND_WORD
-            + ": Lists contacts in the address book."
-            + "Parameters: "
-            + PREFIX_TAG + " TAGNAME...\n"
-            + "Tag argument may be empty."
+            + ": Lists contacts in the address book.\n"
+            + "Usage: "
+            + COMMAND_WORD + " " + SECONDARY_COMMAND_WORD
+            + " [" + PREFIX_TAG + " TAGNAME...]\n"
             + "Example: \n"
             + "- " + COMMAND_WORD + " " + SECONDARY_COMMAND_WORD + "\n"
             + "- " + COMMAND_WORD + " " + SECONDARY_COMMAND_WORD + " " + PREFIX_TAG + " recruiter";
@@ -29,7 +29,8 @@ public class ListPersonCommand extends ListCommand {
     private final Set<Tag> tags;
 
     /**
-     * Creates a ListPersonCommand to list contacts based on tags (may be empty) {@code Person}
+     * Creates a ListPersonCommand to list contacts based on tags (may be empty)
+     * {@code Person}
      */
     public ListPersonCommand(Set<Tag> tags) {
         requireNonNull(tags);

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_MISSING_SECONDARY_COMMAND;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import seedu.address.logic.commands.AddCommand;
@@ -17,6 +18,11 @@ public class AddCommandParser implements Parser<AddCommand> {
     @Override
     public AddCommand parse(String userInput) throws ParseException {
         String secondaryCommandWord = SecondaryCommandSelector.getSecondaryCommandWord(userInput);
+
+        if (secondaryCommandWord == null) {
+            throw new ParseException(String.format(MESSAGE_MISSING_SECONDARY_COMMAND, AddCommand.COMMAND_WORD));
+        }
+
         String args = SecondaryCommandSelector.getArguments(secondaryCommandWord, userInput);
         switch (secondaryCommandWord) {
         case AddPersonCommand.SECONDARY_COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_MISSING_SECONDARY_COMMAND;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import seedu.address.logic.commands.DeleteCommand;
@@ -16,6 +17,11 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     @Override
     public DeleteCommand parse(String userInput) throws ParseException {
         String secondaryCommandWord = SecondaryCommandSelector.getSecondaryCommandWord(userInput);
+
+        if (secondaryCommandWord == null) {
+            throw new ParseException(String.format(MESSAGE_MISSING_SECONDARY_COMMAND, DeleteCommand.COMMAND_WORD));
+        }
+
         String args = SecondaryCommandSelector.getArguments(secondaryCommandWord, userInput);
         switch (secondaryCommandWord) {
         case DeletePersonCommand.SECONDARY_COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_MISSING_SECONDARY_COMMAND;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import seedu.address.logic.commands.ListCommand;
@@ -14,6 +15,11 @@ public class ListCommandParser implements Parser<ListCommand> {
     @Override
     public ListCommand parse(String userInput) throws ParseException {
         String secondaryCommandWord = SecondaryCommandSelector.getSecondaryCommandWord(userInput);
+
+        if (secondaryCommandWord == null) {
+            throw new ParseException(String.format(MESSAGE_MISSING_SECONDARY_COMMAND, ListCommand.COMMAND_WORD));
+        }
+
         String args = SecondaryCommandSelector.getArguments(secondaryCommandWord, userInput);
         switch (secondaryCommandWord) {
         case ListPersonCommand.SECONDARY_COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/SecondaryCommandSelector.java
+++ b/src/main/java/seedu/address/logic/parser/SecondaryCommandSelector.java
@@ -1,22 +1,22 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.parser.exceptions.ParseException;
-
 /**
  * Helper methods for parsing secondary commands
  */
 public abstract class SecondaryCommandSelector {
 
     /**
-     * Get the secondary command word. For example, the command word {@code event} in the comman {@code add event ...}
+     * Get the secondary command word. For example, the command word {@code event}
+     * in the comman {@code add event ...}
+     *
      * @param str The command arguments after the primary command word
      * @return The secondary command word
      */
-    public static String getSecondaryCommandWord(String str) throws ParseException {
+    public static String getSecondaryCommandWord(String str) {
         try {
             return str.split(" ")[1];
         } catch (Exception e) {
-            throw new ParseException("Can not get secondary command");
+            return null;
         }
 
     }
@@ -24,6 +24,7 @@ public abstract class SecondaryCommandSelector {
     /**
      * Get the arguments after secondary command word
      * param str The command arguments after the primary command word
+     *
      * @return The arguments after secondary command word
      */
     public static String getArguments(String secondaryCommandWord, String str) {


### PR DESCRIPTION
Fixed error message as secondary command is part of the internal structure and should not be visible to users.
![image](https://github.com/AY2324S1-CS2103T-W16-1/tp/assets/139637290/d46e5234-39a6-4fd4-a752-03910303ea9f)

Fixed help messages for `list`. The original help is missing description and `TAGNAME` should optional.
![image](https://github.com/AY2324S1-CS2103T-W16-1/tp/assets/139637290/23a23bed-467c-4a1b-be8f-a2773b7609d5)
