### PR TITLE
Fix integer overflow when parsing index

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -43,6 +43,16 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
+
+        try {
+            long longValue = Long.parseLong(trimmedIndex);
+            if (longValue > Integer.MAX_VALUE) {
+                return Index.fromOneBased(Integer.MAX_VALUE);
+            }
+        } catch (Exception e) {
+            throw new ParseException(MESSAGE_INVALID_INDEX);
+        }
+
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }


### PR DESCRIPTION
Fix error whereby the input index by user causes an integer overflow.

![image](https://github.com/AY2324S1-CS2103T-W16-1/tp/assets/139637290/57a0a4a7-2e45-47d7-a371-49435d633a83)
