### PR TITLE
Fix integer overflow error message

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -79,6 +79,8 @@ If you can type fast, KeepInTouch can get your contact management tasks done fas
 
 * `CONTACT_ID` is the number that is on the left of the contact's name in each contact card.
 
+* `CONTACT_ID` should be a positive integer less than 2,147,483,648.
+
 * `NAME` should be alphanumeric, spaces are allowed.
 
 * `PHONE_NUMBER` should be numbers at least 3 digits long.

--- a/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
@@ -21,7 +21,7 @@ public class DeletePersonCommand extends DeleteCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + " "
             + SECONDARY_COMMAND_WORD
             + ": Deletes a contact by its index number used in the displayed contact list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Usage: " + COMMAND_WORD + " " + SECONDARY_COMMAND_WORD + " CONTACT_ID\n"
             + "Example: " + COMMAND_WORD + " " + SECONDARY_COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Contact: %1$s";


### PR DESCRIPTION
When users input an index that is too large, the error message is wrong as the parser reads a negative number. The error message and UG has been changed to address this.
![image](https://github.com/AY2324S1-CS2103T-W16-1/tp/assets/139637290/02c29395-70b4-482f-8e11-84c8906d07b4)
![image](https://github.com/AY2324S1-CS2103T-W16-1/tp/assets/139637290/afae94b1-c19d-4bfc-95e6-d1673c65c1f3)

